### PR TITLE
Update 4.x README.md

### DIFF
--- a/04-vpcs/README.md
+++ b/04-vpcs/README.md
@@ -241,6 +241,8 @@ Add another ACL to your private subnet:
 - Allow all ports for egress traffic, but restrict replies to the
   public subnet.
 
+- The [Network ACL is stateless](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-network-acls.html), on the public ACL the return traffic from this private subnet will need to be allowed. 
+
 _Verify again that you can reach your instance._
 
 ### Retrospective 4.1


### PR DESCRIPTION
Added a note or comment about allowing the private subnet traffic back into the public subnet for end of 4.1.8. This has caused a few of us to be stumped on what wasn't working when it appeared correct. This note likely will save a few hours of frustration for some.

Also linked to the aws doc where a bullet on it being stateless can be found, but didn't go so far as to say one should search for it. 