### PR TITLE
Fixed missing space in kubectl run command

### DIFF
--- a/15-Kubernetes/README.md
+++ b/15-Kubernetes/README.md
@@ -197,7 +197,7 @@ Run the command `kubectl get pods`.  The results should show that there
 are not any pods deployed in the default namespace.
 
 - Run the command:
-  `kubectl run --generator=run-pod/v1 busybox --image=busybox:latest --sleep 3000`
+  `kubectl run --generator=run-pod/v1 busybox --image=busybox:latest -- sleep 3000`
 
 > The result of the command should be `pod/busybox created`
 
@@ -252,7 +252,7 @@ and used in to lock in pod configuration.
 
 - Run the command:
   `kubectl run --generator=run-pod/v1 busybox --image=busybox:latest \
-  --dry-run -o=yaml --sleep 3000 > busybox-pod-definition-lab23.yaml`
+  --dry-run -o=yaml -- sleep 3000 > busybox-pod-definition-lab23.yaml`
 
 - Open `busybox-pod-definition-lab22.yaml`
   - Compare this definition file to the file


### PR DESCRIPTION
## Identify the Bug
Issue: #8 
There are spaces missing from the `kubectl` commands causing the entrypoint command to be misinterpreted as a `kubectl` command line option.

## Description of the Change
I inserted a space between `--` delimiter and the entrypoint command.

## Verification Process
Tested with `kubectl` v1.19.3 

Before changes: 
`Error: unknown flag: --sleep`

After changes pod is successfully created. 
```
NAME      READY   STATUS    RESTARTS   AGE
busybox   1/1     Running   0          18s
```

## Release Notes
Fixed malformed `kubectl` commands in Kubernetes chapter. 

