### PR TITLE
Module 00. Implementing script to automate creation of temporary credentials using an MFA token

### DIFF
--- a/00-dev-environment/getTmpSecurityToken.py
+++ b/00-dev-environment/getTmpSecurityToken.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+import sys 
+import boto3
+from utils.pyColors import MinStyle
+
+st_profile='st_jh_labs'
+mfa_token=sys.argv[1]
+mfa_arn='arn:aws:iam::324320755747:mfa/john.hunter.labs'
+
+print(f'\nMFA Token: {mfa_token}\n')
+
+session = boto3.Session(profile_name=(st_profile))
+st_profile_sts_client = session.client('sts')
+caller_identity_response = st_profile_sts_client.get_caller_identity()
+
+user_id=caller_identity_response.get("UserId")
+account=caller_identity_response.get("Account")
+arn=caller_identity_response.get("Arn")
+
+print(f'UserId: {user_id}')
+print(f'Account: {account}')
+print(f'Arn: {arn}\n')
+
+dur_seconds=43200 # 12 hour duration
+session_token_response = st_profile_sts_client.get_session_token(
+    DurationSeconds=(dur_seconds),
+    SerialNumber=(mfa_arn),
+    TokenCode=(mfa_token)
+)
+
+access_key_id=session_token_response.get("Credentials").get("AccessKeyId")
+secret_access_key=session_token_response.get("Credentials").get("SecretAccessKey")
+session_token=session_token_response.get("Credentials").get("SessionToken")
+
+# print(f'\n')
+print(f'New Temporary Session Credentials')
+print(f'{MinStyle.LIGHTGREEN}{MinStyle.DIV_SINGLE_SHORT}{MinStyle.RESET}')
+print(f'{MinStyle.LIGHTCYAN}AccessKeyId: {MinStyle.YELLOW}{access_key_id}{MinStyle.RESET}')
+print(f'{MinStyle.LIGHTCYAN}SecretAccessKey: {MinStyle.YELLOW}{secret_access_key}{MinStyle.RESET}')
+print(f'{MinStyle.LIGHTCYAN}SessionToken: {MinStyle.YELLOW}{session_token}{MinStyle.RESET}')
+print()
+

--- a/00-dev-environment/setLabsProfileCreds.py
+++ b/00-dev-environment/setLabsProfileCreds.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+
+import sys
+import os 
+import boto3
+import configparser
+from utils.pyColors import MinStyle
+
+config=configparser.ConfigParser()
+
+st_profile='st_jh_labs'
+mfa_creds_profile='st_mfa_creds'
+mfa_token=sys.argv[1]
+MODFILE='/Users/John.Hunter/.aws/credentials'
+mfa_arn='arn:aws:iam::324320755747:mfa/john.hunter.labs'
+
+print(f'\nMFA Token: {mfa_token}\n')
+
+st_session = boto3.Session(profile_name=(st_profile))
+st_profile_sts_client = st_session.client('sts')
+caller_identity_response = st_profile_sts_client.get_caller_identity()
+
+print(f'{MinStyle.PINK}STS Caller Identity values{MinStyle.RESET}')
+print(f'{MinStyle.LIGHTGREY}{MinStyle.DIV_SINGLE_SHORT}{MinStyle.RESET}')
+print(f'{MinStyle.LIGHTCYAN}UserId: {MinStyle.WHITE}{caller_identity_response.get("UserId")}{MinStyle.RESET}')
+print(f'{MinStyle.LIGHTCYAN}Account: {MinStyle.WHITE}{caller_identity_response.get("Account")}{MinStyle.RESET}')
+print(f'{MinStyle.LIGHTCYAN}Arn: {MinStyle.WHITE}{caller_identity_response.get("Arn")}{MinStyle.RESET}')
+print()
+
+
+dur_seconds=43200 # 12 hour duration
+session_token_response = st_profile_sts_client.get_session_token(
+    DurationSeconds=(dur_seconds),
+    SerialNumber=(mfa_arn),
+    TokenCode=(mfa_token)
+)
+access_key_id=session_token_response.get("Credentials").get("AccessKeyId")
+secret_access_key=session_token_response.get("Credentials").get("SecretAccessKey")
+session_token=session_token_response.get("Credentials").get("SessionToken")
+
+config.read(f'{MODFILE}')
+
+# print(f'Profile Sections: {config.sections()}')
+print(f'{MinStyle.PINK}Temporary Profile Credentials Original Values')
+print(f'{MinStyle.LIGHTGREY}{MinStyle.DIV_SINGLE_SHORT}{MinStyle.RESET}')
+print(f'{MinStyle.LIGHTCYAN}Profile: {MinStyle.YELLOW}{mfa_creds_profile}{MinStyle.RESET}')
+print(f'{MinStyle.LIGHTCYAN}AccessKeyId: {MinStyle.YELLOW}{config.get(f"{mfa_creds_profile}", "aws_access_key_id")}{MinStyle.RESET}')
+print(f'{MinStyle.LIGHTCYAN}SecretAccessKey: {MinStyle.YELLOW}{config.get(f"{mfa_creds_profile}", "aws_secret_access_key")}{MinStyle.RESET}')
+print(f'{MinStyle.LIGHTCYAN}SessionToken: {MinStyle.YELLOW}{config.get(f"{mfa_creds_profile}", "aws_session_token")}{MinStyle.RESET}')
+
+config.set(f'{mfa_creds_profile}', 'aws_access_key_id', f'{access_key_id}')
+config.set(f'{mfa_creds_profile}', 'aws_secret_access_key', f'{secret_access_key}')
+config.set(f'{mfa_creds_profile}', 'aws_session_token', f'{session_token}')
+
+with open ((MODFILE), 'w') as configfile:
+    config.write(configfile)
+
+print()
+print(f'{MinStyle.PINK}New Temporary Session Token Credentials')
+print(f'{MinStyle.LIGHTGREY}{MinStyle.DIV_SINGLE_SHORT}{MinStyle.RESET}')
+print(f'{MinStyle.LIGHTCYAN}Modified Profile: {MinStyle.YELLOW}{mfa_creds_profile}{MinStyle.RESET}')
+print(f'{MinStyle.LIGHTCYAN}AccessKeyId: {MinStyle.YELLOW}{access_key_id}{MinStyle.RESET}')
+print(f'{MinStyle.LIGHTCYAN}SecretAccessKey: {MinStyle.YELLOW}{secret_access_key}{MinStyle.RESET}')
+print(f'{MinStyle.LIGHTCYAN}SessionToken: {MinStyle.YELLOW}{session_token}{MinStyle.RESET}')
+print()
+
+
+# print(f'{MinStyle.LIGHTCYAN}AWS_PROFILE= {MinStyle.YELLOW}{os.getenv("AWS_PROFILE")}{MinStyle.RESET}\n')
+# os.environ['AWS_PROFLE']='st_mfa_creds'
+# print(f'{MinStyle.LIGHTCYAN}AWS_PROFILE= {MinStyle.YELLOW}{os.getenv("AWS_PROFILE")}{MinStyle.RESET}\n')
+
+iam_session = boto3.Session(profile_name=(mfa_creds_profile))
+iam_client = iam_session.client('iam')
+
+get_user_response=iam_client.get_user()
+
+print(f'{MinStyle.PINK}IAM get-user Response using tmp session credentials{MinStyle.RESET}')
+print(f'{MinStyle.LIGHTGREY}{MinStyle.DIV_SINGLE_SHORT}{MinStyle.RESET}')
+print(f'{MinStyle.LIGHTCYAN}UserName: {MinStyle.WHITE}{get_user_response.get("User").get("UserName")}{MinStyle.RESET}')
+print(f'{MinStyle.LIGHTCYAN}UserId: {MinStyle.WHITE}{get_user_response.get("User").get("UserId")}{MinStyle.RESET}')
+print(f'{MinStyle.LIGHTCYAN}Arn: {MinStyle.WHITE}{get_user_response.get("User").get("Arn")}{MinStyle.RESET}')
+print()
+

--- a/00-dev-environment/setLabsProfileCreds.sh
+++ b/00-dev-environment/setLabsProfileCreds.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+
+# ===========================================================================================================
+# Description:
+#     This script swaps the aws profile ENV variables to a new one
+# Arguments:
+#     The valid profile name in the aws config file to swap to
+#
+# NOTE: You MUST source this script in order to change the env variables in the current shell
+#       example from command prompt -->  $ . swapAwsProfile.sh <newProfile>
+#
+#       If not done, the script is run in its own, new shell and so the export will only occur
+#       there and not in the current shell.
+# ===========================================================================================================
+
+# setting some color varibles for use
+#  --------------------------------------
+BLACK=$(tput setaf 0)
+RED=$(tput setaf 1)
+GREEN=$(tput setaf 2)
+YELLOW=$(tput setaf 3)
+DARK_BLUE=$(tput setaf 4)
+MAGENTA=$(tput setaf 5)
+SKY_BLUE=$(tput setaf 6)
+WHITE=$(tput setaf 7)
+GREY=$(tput setaf 8)
+BRICK_RED=$(tput setaf 9)
+BRIGHT_GREEN=$(tput setaf 10)
+BRIGHT_YELLOW=$(tput setaf 11)
+BLUE=$(tput setaf 12)
+PURPLE=$(tput setaf 13)
+CYAN=$(tput setaf 14)
+BRIGHT_WHITE=$(tput setaf 15)
+DIRTY_WHITE=$(tput setaf 250)
+
+doubleDiv=================================================================================================
+singleLongDiv=------------------------------------------------------------------------------------------------
+singleDiv=----------------------------
+
+if [ -z "$1" ] ; then
+    printf "\n\n%s\n\n" " ${RED}ERROR   ${BRIGHT_WHITE}No AWS Profile supplied${DIRTY_WHITE}"
+    printf "%s\n" " ${BRIGHT_WHITE}Available profiles are:"
+    printf "%s\n" "${BRIGHT_WHITE}${singleDiv}${BRIGHT_YELLOW}"
+    aws configure list-profiles
+    printf "\n\n${DIRTY_WHITE}"
+    exit 1
+else
+    initialProfile=st_jh_labs
+    newProfile=tmp_mfa_creds
+    mfaToken=$1
+    modFile="/Users/John.Hunter/.aws/credentials"
+    tmpMfaCredential=""
+    mfaCredential=""
+
+    export AWS_PROFILE=$initialProfile AWS_DEFAULT_PROFILE=$initialProfile
+    # aws sts get-caller-identity
+
+    # echo
+    # echo "mfaToken=$mfaToken"
+
+    tmpMfaCredential=$(aws sts get-session-token --serial-number arn:aws:iam::324320755747:mfa/john.hunter.labs --token-code $mfaToken --query "[Credentials.[AccessKeyId, SecretAccessKey, SessionToken]]" --output text)
+
+    mfaCredential=$(echo $tmpMfaCredential | tr -d [:space:])
+    accessKeyId=$(echo $tmpMfaCredential | cut -d' ' -f1)
+    secretAccessKey=$(echo $tmpMfaCredential | cut -d' ' -f2)
+    sessionToken=$(echo $tmpMfaCredential | cut -d' ' -f3)
+
+    # echo "AccessKeyId=$accessKeyId"
+    # echo "SecretAccessKey=$secretAccessKey"
+    # echo "SessionToken=$sessionToken"
+    
+    newAccessKeyIdLine="aws_access_key_id = $accessKeyId"
+    newSecretAccessKeyLine="aws_secret_access_key = $secretAccessKey"
+    newSessionTokenLine="aws_session_token = $sessionToken"
+    escapedAccessKeyIdLine=$(echo $newAccessKeyIdLine | sed -e 's/[]$/.*[\^]/\\&/g')
+    escapedSecretAccessKeyLine=$(echo $newSecretAccessKeyLine | sed -e 's/[]$/.*[\^]/\\&/g')
+    escapedSessionTokenLine=$(echo $newSessionTokenLine | sed -e 's/[]$/.*[\^]/\\&/g')
+
+    sed -i '' -e "s/aws_access_key_id = .*/${escapedAccessKeyIdLine}/" $modFile
+    sed -i '' -e "s/aws_secret_access_key = .*/${escapedSecretAccessKeyLine}/" $modFile
+    sed -i '' -e "s/aws_session_token = .*/${escapedSessionTokenLine}/" $modFile
+
+    printf "\n%s\n" "${BRIGHT_YELLOW}Previous ENV values"
+    printf "%s\n"   "${BRIGHT_WHITE}AWS_PROFILE =         ${DIRTY_WHITE}$AWS_PROFILE${DIRTY_WHITE}"
+    printf "%s\n\n" "${BRIGHT_WHITE}AWS_DEFAULT_PROFILE = ${DIRTY_WHITE}$AWS_DEFAULT_PROFILE${DIRTY_WHITE}"
+
+    export AWS_PROFILE=$newProfile AWS_DEFAULT_PROFILE=$newProfile
+
+    printf "%s\n"   "${BRIGHT_YELLOW}New ENV values"
+    printf "%s\n"   "${BRIGHT_WHITE}AWS_PROFILE =         ${CYAN}$AWS_PROFILE${DIRTY_WHITE}"
+    printf "%s\n\n" "${BRIGHT_WHITE}AWS_DEFAULT_PROFILE = ${CYAN}$AWS_DEFAULT_PROFILE${DIRTY_WHITE}"
+    echo
+
+    aws iam get-user
+    echo
+fi
+

--- a/01-cloudformation/minimal-s3.yaml
+++ b/01-cloudformation/minimal-s3.yaml
@@ -1,0 +1,12 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+
+Description:
+  The most minimal S3 stack possible
+
+Resources:
+  s3Bucket:
+    Type: AWS::S3::Bucket
+    Properties: 
+      AccessControl: PublicReadWrite
+      BucketName: jh-bucket

--- a/utils/pyColors.py
+++ b/utils/pyColors.py
@@ -1,0 +1,68 @@
+class MoreStyle:
+    '''
+    Summary: Reset all colors with MoreStyle.reset; two
+    sub classes Fg for foreground and Bg for background; 
+    use as MoreStyle.subclass.colorname. # i.e. MoreStyle.Fg.RED or 
+    MoreStyle.bg.GREEN also, the generic BOLD, DISABLE, # UNDERLINE, 
+    REVERSE, STRIKETHROUGH, # and INVISIBLE work with the main 
+    class i.e. MoreStyle.BOLD
+    ''' 
+    RESET='\033[0m'
+    BOLD='\033[01m'
+    DISABLE='\033[02m'
+    UNDERLINE='\033[04m'
+    REVERSE='\033[07m'
+    STRIKETHROUGH='\033[09m'
+    INVISIBLE='\033[08m'
+    class Fg:
+        BLACK='\033[30m'
+        RED='\033[31m'
+        GREEN='\033[32m'
+        ORANGE='\033[33m'
+        BLUE='\033[34m'
+        PURPLE='\033[35m'
+        CYAN='\033[36m'
+        LIGHTGREY='\033[37m'
+        DARKGREY='\033[90m'
+        LIGHTRED='\033[91m'
+        LIGHTGREEN='\033[92m'
+        YELLOW='\033[93m'
+        LIGHTBLUE='\033[94m'
+        PINK='\033[95m'
+        LIGHTCYAN='\033[96m'
+    class Bg:
+        BLACK='\033[40m'
+        RED='\033[41m'
+        GREEN='\033[42m'
+        ORANGE='\033[43m'
+        BLUE='\033[44m'
+        PURPLE='\033[45m'
+        CYAN='\033[46m'
+        LIGHTGREY='\033[47m'
+
+
+class MinStyle():
+    """
+    Summary: Provides a minimal color and style implementation
+    """
+    BLACK='\033[30m'
+    RED='\033[31m'
+    GREEN='\033[32m'
+    ORANGE='\033[33m'
+    BLUE='\033[34m'
+    PURPLE='\033[35m'
+    CYAN='\033[36m'
+    LIGHTGREY='\033[37m'
+    DARKGREY='\033[90m'
+    LIGHTRED='\033[91m'
+    LIGHTGREEN='\033[92m'
+    YELLOW='\033[93m'
+    LIGHTBLUE='\033[94m'
+    PINK='\033[95m'
+    LIGHTCYAN='\033[96m'
+    WHITE = '\033[97m'
+    UNDERLINE = '\033[4m'
+    RESET = '\033[0m'
+    DIV_DOUBLE='================================================================================================'
+    DIV_SINGLE_LONG='------------------------------------------------------------------------------------------------'
+    DIV_SINGLE_SHORT='--------------------------------------'


### PR DESCRIPTION

### Code requirement

Create a script to automate the gathering of new credentials using an MFA token and enabling a profile to use them.

Created three scripts.
1. `setTempSessionCreds.py` - (primary script) A python script implementing the functionality to get the temporary session token and update a specified profile in the .aws/credentials file that provided access to aws
2. `getTmpSecurityToken.py` - A python script which obtained the temporary session token with the given mfa token.
3. `setLabsProfileCreds.sh` - Bash script which implemented the functionality as the primary python scrip

### Description of the Change

The script takes an MFA token and then performs several steps.

1. Using a hard-coded profile, uses the `aws sts get-caller-identity` command to validate that the profile works and displays the results
2. Using the MFA token, obtains the new temporary session credentials that include the temporary session token.
3. Gets and displays the values of the temp_creds_profile that is used for temporary access
4. Modifies the values of the temp_creds_profile and writes the out to the file
5. Gets and displays the new values of the temp_creds_profile
6. Validates that the temp_creds_profile successfully enable aws programmatic access by using the `aws iam get-user` command with the new creds
7. Displays the returned output of the `aws iam get-user` command

### Next Implementation Steps
All of the following were not implemented simply due to time.  The base script works, but if it was being done for a client I would implement all of listed items below. And if I have time, I will probably go back and implement some of this later.

**_Additional Implementation Items_**
- Create more sophisticated error checking/handling
  - Validating that the MFA token is a valid value
  - Better and more graceful handling if:
    - The default, hard-coded profile is not valid. Display the error and exit.
    - Using the MFA Token to obtain a temporary session token fails.
    - The new values failed to write out successfully to the credentials file.
    - If using the new temporary credentials fail when attempting to execute an aws cli command
- A command-line option to switch between verbose output and minimal output.  Currently, it is very verbose and it would be nice to have the default behavior be minimal output, simply displaying that the operation is in progress followed by a success/failure message, and that using the verbose option would output the current level of detail.

### Alternate Designs

The following were considered but I did not implement them due to time as I wanted to continue on with the next modules. The improvements would all have been about making the script more robust and user friendly but the underlying capability of taking an MFA token and getting a session token to create a temporary set of credentials would not have changed.

- One option was to require two arguments to the script, first the MFA token and second the profile to modify. That way, the user could input the profile name to be modified and the script would be more flexible and dynamic without simply using a hard-coded profile. 

### Possible Drawbacks

- The script is very verbose when it doesn't have to be. It was done initially as a way to validate that it was working but it is too much output for everyday use.
- As implemented, the used profiles are hard-coded. That is a definite drawback as it would have to be changed for every user to match the user's profiles. Not doing so will cause the script to fail.

### Verification Process

Included several steps in the script that needed to work correctly in order to validate the successful creation of temporary credits. 

The final validation was actually using the profile containing the new, temporary credentials with the `aws iam get-user` command. The command will only succeed if the temporary credentials were valid.