### PR TITLE
Updating README to provide details on how to use env vars and --profile

### DIFF
--- a/00-dev-environment/README.md
+++ b/00-dev-environment/README.md
@@ -46,7 +46,8 @@ GitHub code repositories, and, optionally, AWS Cloud9 for your development envir
 
 #### Lab 0.1.1: AWS Access Keys
 
-Add your AWS access key and secret key to your laptop. You
+Add your AWS access key and secret key to your laptop before enabling MFA. You won't be able to retrieve your 
+token if the access key and secret key are not added to your credentials file.You
 will need to [install the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-welcome.html)
 and then run some simple commands to confirm access using your keys:
 

--- a/00-dev-environment/README.md
+++ b/00-dev-environment/README.md
@@ -64,8 +64,6 @@ _Never_ commit credentials to a git repo.
   credentials using your MFA device and STS. You can do this in a few
   ways. The first way would be to request the token from STS via the CLI.
 
-*NOTE*
-1. You will need to obtain your 
 ##### Option 1: Getting Credentials via STS command
 
 ```shell
@@ -100,6 +98,7 @@ aws_session_token = AQoDYXdzEJr...<remainder of security token>
 ```
 
 Now set AWS_PROFILE to temp in your env:
+
 ```shell
 $ export AWS_ACCESS_KEY_ID=<temp aws_access_key_id >
 $ export AWS_SECRET_ACCESS_KEY=<temp aws_secret_access_key>
@@ -117,13 +116,13 @@ You should be able to access any of the resources you're
 authorized to in the labs account. These tokens will last approximately
 12 hours before needing to be reset using the process above.
 
-###### Exercise 0.1.1: MFA Script
+##### Exercise 0.1.1: MFA Script
 
 1. Create a script to automate the gathering and assigning of the temporary
   AWS MFA credentials from Option 1.
 1. Try to reduce the amount of manual input as much as possible.
 
-###### Question 0.1.1: 1
+##### Question 0.1.1: 1
 
 What method did you use to store the aws credentials?  What are some other
 options?

--- a/00-dev-environment/README.md
+++ b/00-dev-environment/README.md
@@ -47,8 +47,8 @@ GitHub code repositories, and, optionally, AWS Cloud9 for your development envir
 #### Lab 0.1.1: AWS Access Keys
 
 Add your AWS access key and secret key to your laptop before enabling MFA. You won't
-be able to retrieve your token if the access key and secret key are not added to your
-credentials file.You will need to
+be able to retrieve your token if the access key and secret key are not added
+to your credentials file.You will need to
 [install the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-welcome.html)
 and then run some simple commands to confirm access using your keys:
 

--- a/00-dev-environment/README.md
+++ b/00-dev-environment/README.md
@@ -64,6 +64,8 @@ _Never_ commit credentials to a git repo.
   credentials using your MFA device and STS. You can do this in a few
   ways. The first way would be to request the token from STS via the CLI.
 
+*NOTE*
+1. You will need to obtain your 
 ##### Option 1: Getting Credentials via STS command
 
 ```shell
@@ -97,8 +99,21 @@ aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 aws_session_token = AQoDYXdzEJr...<remainder of security token>
 ```
 
-Now set AWS_PROFILE to temp in your env, or set the --profile flag to temp when
-running awscli. You should be able to access any of the resources you're
+Now set AWS_PROFILE to temp in your env:
+```shell
+$ export AWS_ACCESS_KEY_ID=<temp aws_access_key_id >
+$ export AWS_SECRET_ACCESS_KEY=<temp aws_secret_access_key>
+$ export AWS_DEFAULT_REGION=<region>
+```
+
+or set the --profile flag to temp when
+running awscli:
+
+```shell
+aws s3 ls --profile temp
+```
+
+You should be able to access any of the resources you're
 authorized to in the labs account. These tokens will last approximately
 12 hours before needing to be reset using the process above.
 

--- a/00-dev-environment/README.md
+++ b/00-dev-environment/README.md
@@ -100,9 +100,9 @@ aws_session_token = AQoDYXdzEJr...<remainder of security token>
 Now set AWS_PROFILE to temp in your env:
 
 ```shell
-$ export AWS_ACCESS_KEY_ID=<temp aws_access_key_id >
-$ export AWS_SECRET_ACCESS_KEY=<temp aws_secret_access_key>
-$ export AWS_DEFAULT_REGION=<region>
+export AWS_ACCESS_KEY_ID=<temp aws_access_key_id >
+export AWS_SECRET_ACCESS_KEY=<temp aws_secret_access_key>
+export AWS_DEFAULT_REGION=<region>
 ```
 
 or set the --profile flag to temp when

--- a/00-dev-environment/README.md
+++ b/00-dev-environment/README.md
@@ -46,10 +46,11 @@ GitHub code repositories, and, optionally, AWS Cloud9 for your development envir
 
 #### Lab 0.1.1: AWS Access Keys
 
-Add your AWS access key and secret key to your laptop before enabling MFA. You won't be able to retrieve your 
-token if the access key and secret key are not added to your credentials file.You
-will need to [install the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-welcome.html)
-and then run some simple commands to confirm access using your keys:
+Add your AWS access key and secret key to your laptop before enabling MFA. You won't 
+be able to retrieve your token if the access key and secret key are not added to your 
+credentials file.You will need to [install the AWS CLI]
+(https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-welcome.html) and then 
+run some simple commands to confirm access using your keys:
 
 - [list-buckets](https://docs.aws.amazon.com/cli/latest/reference/s3api/list-buckets.html)
 - [describe-instances](https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-instances.html)

--- a/00-dev-environment/README.md
+++ b/00-dev-environment/README.md
@@ -48,7 +48,8 @@ GitHub code repositories, and, optionally, AWS Cloud9 for your development envir
 
 Add your AWS access key and secret key to your laptop before enabling MFA. You won't
 be able to retrieve your token if the access key and secret key are not added to your
-credentials file.You will need to [install the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-welcome.html)
+credentials file.You will need to
+[install the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-welcome.html)
 and then run some simple commands to confirm access using your keys:
 
 - [list-buckets](https://docs.aws.amazon.com/cli/latest/reference/s3api/list-buckets.html)

--- a/00-dev-environment/README.md
+++ b/00-dev-environment/README.md
@@ -46,11 +46,10 @@ GitHub code repositories, and, optionally, AWS Cloud9 for your development envir
 
 #### Lab 0.1.1: AWS Access Keys
 
-Add your AWS access key and secret key to your laptop before enabling MFA. You won't 
-be able to retrieve your token if the access key and secret key are not added to your 
-credentials file.You will need to [install the AWS CLI]
-(https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-welcome.html) and then 
-run some simple commands to confirm access using your keys:
+Add your AWS access key and secret key to your laptop before enabling MFA. You won't
+be able to retrieve your token if the access key and secret key are not added to your
+credentials file.You will need to [install the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-welcome.html)
+and then run some simple commands to confirm access using your keys:
 
 - [list-buckets](https://docs.aws.amazon.com/cli/latest/reference/s3api/list-buckets.html)
 - [describe-instances](https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-instances.html)


### PR DESCRIPTION
I noticed that this detail provided in the README might be helpful for engineer that are not aware on how to test credentials.