### PR TITLE
Fix bad fenced-code-block labels. Formatting to help other markdown parsers.

### DIFF
--- a/00-dev-environment/README.md
+++ b/00-dev-environment/README.md
@@ -67,16 +67,16 @@ _Never_ commit credentials to a git repo.
 
 ##### Option 1: Getting Credentials via STS command
 
-```shell
+```sh
 aws sts get-session-token \
     --serial-number arn:aws:iam::324320755747:mfa/USERNAME \
     --token-code 123456` \
 /
 ```
 
-This will return json containing the temporarily credentials.
+This will return JSON containing the temporarily credentials.
 
-```shell
+```json
 "Credentials": {
     "SecretAccessKey": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
     "SessionToken": "AQoDYXdzEJr...<remainder of security token>",
@@ -89,7 +89,7 @@ This will return json containing the temporarily credentials.
 Using these temporary credentials you will need to edit your `.aws/credentials`
 file and change the security configuration for the profile to be used.
 
-```shell
+```ini
 [temp]
 output = json
 region = us-east-1
@@ -100,7 +100,7 @@ aws_session_token = AQoDYXdzEJr...<remainder of security token>
 
 Now set AWS_PROFILE to temp in your env:
 
-```shell
+```sh
 export AWS_ACCESS_KEY_ID=<temp aws_access_key_id >
 export AWS_SECRET_ACCESS_KEY=<temp aws_secret_access_key>
 export AWS_DEFAULT_REGION=<region>
@@ -109,7 +109,7 @@ export AWS_DEFAULT_REGION=<region>
 or set the --profile flag to temp when
 running awscli:
 
-```shell
+```sh
 aws s3 ls --profile temp
 ```
 
@@ -148,7 +148,7 @@ and start over.
 To use aws-vault for temporary credential management is simple. You need to add
 the arn of your mfa token to your profiles config in `~/.aws/config` like so:
 
-```shell
+```ini
 [profile MY_PROFILE]
 output = json
 region = us-east-1

--- a/05-ec2/README.md
+++ b/05-ec2/README.md
@@ -350,7 +350,7 @@ done this already, try it and repeat Lab 5.2.3.
 > Hint: when you want to put a bunch of commands into UserData in a
 > YAML template, use this format to keep it readable:
 
-```
+```yaml
 UserData:
   Fn::Base64: !Sub |
     # bash code goes here just like a normal script.

--- a/15-Kubernetes/README.md
+++ b/15-Kubernetes/README.md
@@ -197,9 +197,13 @@ Run the command `kubectl get pods`.  The results should show that there
 are not any pods deployed in the default namespace.
 
 - Run the command:
-  `kubectl run --generator=run-pod/v1 busybox --image=busybox:latest -- sleep 3000`
+  ```sh
+  kubectl run --generator=run-pod/v1 busybox \
+  --image=busybox:latest -- sleep 3000
+  ```
 
-> The result of the command should be `pod/busybox created`
+  The result of the command should be:
+  > `pod/busybox created`
 
 - In the `kubectl` command above the option `--generator=run-pod/v1` is
   used to launch a single pod
@@ -251,8 +255,10 @@ Definition files are useful because they can be put into version control
 and used in to lock in pod configuration.
 
 - Run the command:
-  `kubectl run --generator=run-pod/v1 busybox --image=busybox:latest \
-  --dry-run -o=yaml -- sleep 3000 > busybox-pod-definition-lab23.yaml`
+  ```sh
+  kubectl run --generator=run-pod/v1 busybox --image=busybox:latest \
+  --dry-run -o=yaml -- sleep 3000 > busybox-pod-definition-lab23.yaml
+  ```
 
 - Open `busybox-pod-definition-lab22.yaml`
   - Compare this definition file to the file
@@ -286,7 +292,8 @@ Now that we've got a pod definition file create we can launch a pod with it.
 
 - Run the command: `kubectl create -f busybox-pod-definition-lab23.yaml`
 
-> The result of the command should be `pod/busybox created`
+  The result of the command should be:
+  > `pod/busybox created`
 
 - Run command `kubectl get pods`. The newly created pod should appear in
   the list.
@@ -316,9 +323,11 @@ using the same methods.
 #### Lab 15.3.1: Standing Up Deployment Imperatively
 
 - Run the command:
-  `kubectl create deployment nginx-deployment --image=nginx:latest`
-
-> The result of the command should be `deployment.apps/nginx-deployment created`
+  ```sh
+  kubectl create deployment nginx-deployment --image=nginx:latest
+  ```
+  The result of the command should be:
+  > `deployment.apps/nginx-deployment created`
 
 - Try running the [kubectl](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#-strong-getting-started-strong-)
   to get the list of deployments present in the cluster.
@@ -377,8 +386,10 @@ This section will go over creating deployment definition files using
 `kubectl`.
 
 - Run the command:
-  `kubectl create deployment nginx-deployment --image=nginx:latest \
-  --dry-run -o=yaml > nginx-deployment-lab33.yaml`
+  ```sh
+  kubectl create deployment nginx-deployment --image=nginx:latest \
+  --dry-run -o=yaml > nginx-deployment-lab33.yaml
+  ```
   to generate a deployment definition file.
 - Compare this newly created definition file to the one created in the
   previous lesson.
@@ -634,9 +645,11 @@ In this section we'll be setting the deployment up with a
 so we can access it externally.
 
 - Run the command:
-  `kubectl expose deployment custom-deployment --type=LoadBalancer \
-  --name=custom-service --dry-run -o=yaml >> custom-service.yaml` to
-  generate the service definition file.
+  ```sh
+  kubectl expose deployment custom-deployment --type=LoadBalancer \
+  --name=custom-service --dry-run -o=yaml >> custom-service.yaml
+  ```
+  to generate the service definition file.
 - Open the file and inspect the fields.
 - The `type:` field under the `spec:` field specifies what type of service
   this will be.  Kubernetes supports [other service types](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types)

--- a/15-Kubernetes/sample_app/README.md
+++ b/15-Kubernetes/sample_app/README.md
@@ -5,7 +5,7 @@
 1. Run `docker build .`
 1. Run
 
-    ```bash
+    ```sh
     docker run -p 8080:3000 \
     --env REACT_APP_BG_COLOR=<color of choice> <image hash from build command>
     ```

--- a/16-SAM/README.md
+++ b/16-SAM/README.md
@@ -92,7 +92,7 @@ application.
 
 - Use the SAM CLI to initialize a new application.
 
-```bash
+```sh
 sam init --runtime python3.7
 ```
 
@@ -136,7 +136,7 @@ that makes working with events very easy.
 - Looks at the different options available for an event by using the
   `--help` flag.
 
-  ```bash
+  ```sh
   sam local generate-event apigateway aws-proxy --help
   ```
 
@@ -154,18 +154,18 @@ directly or we can spin up an API reachable at `localhost`.
 
 - Invoke the lambda function directly.
 
-  ```bash
+  ```sh
   sam local invoke "HelloWorldFunction" -e events/event.json
   ```
 
 - Start the api and curl the `/hello` endpoint integrated with the
   lambda function.
 
-  ```bash
+  ```sh
   sam local start-api
   ```
 
-  ```bash
+  ```sh
   curl http://127.0.0.1:3000/hello
   ```
 
@@ -215,7 +215,7 @@ to store packaged artifacts.
 
 - Create an S3 bucket using the AWS CLI.
 
-  ```bash
+  ```sh
   aws s3 mb s3://<bucket> --region <region>
   ```
 
@@ -223,7 +223,7 @@ Once the bucket is created, the application can be built and packaged.
 
 - Run the SAM CLI build and package commands.
 
-  ```bash
+  ```sh
   sam build && sam package --output-template packaged.yaml --s3-bucket <bucket>
   ```
 
@@ -237,7 +237,7 @@ easily referenced in AWS and will not conflict with any other stacks.
 
 - Run the SAM CLI deploy command.
 
-  ```bash
+  ```sh
   sam deploy --template-file packaged.yaml --capabilities CAPABILITY_IAM \
   --stack-name <stack>
   ```
@@ -252,7 +252,7 @@ flag need to be supplied?_
 
 - Inspect the stack outputs using the AWS CLI.
 
-  ```bash
+  ```sh
   aws cloudformation describe-stacks --stack-name <stack> \
   --query "Stacks[].Outputs"
   ```
@@ -266,7 +266,7 @@ the stack back down, otherwise investigate what went wrong.
 _What resources were created for this stack that were not explicitly
 defined in the template?_
 
-```bash
+```sh
 aws cloudformation delete-stack --stack-name <stack>
 ```
 
@@ -345,7 +345,7 @@ messages.
   definition.
 - Generate a new SQS event.
 
-  ```bash
+  ```sh
   sam local generate-event sqs receive-message
   ```
 
@@ -407,13 +407,13 @@ a container, providing Docker is installed.
 
 - Start DynamoDB using Docker with the following command:
 
-  ```bash
+  ```sh
   docker run -p 8000:8000 amazon/dynamodb-local
   ```
 
 - Ensure DynamoDB is reachable.
 
-  ```bash
+  ```sh
   aws dynamodb list-tables --endpoint-url http://localhost:8000
   ```
 
@@ -452,7 +452,7 @@ Can you determine a way to invoke the function directly?_
  JSON with a table definition. Replace the TableLogicalID value with the
  name used in the SAM template definition and run the following:
 
-```bash
+```sh
 aws dynamodb create-table --cli-input-json file://create-table.json \
 --endpoint-url http://localhost:8000
 ```
@@ -491,7 +491,7 @@ Run the API locally and curl the `/write` endpoint. If everything worked
 as it should, the following command should indicate new records were
 indeed added to the local table:
 
-```bash
+```sh
 aws dynamodb scan --table-name <table_name> --endpoint-url http://localhost:8000
 ```
 
@@ -577,7 +577,7 @@ accomplishes a few things.
 
 - To get more familiar with these concepts, create a new SAM application.
 
-  ```bash
+  ```sh
   sam init --runtime nodejs8.10
   ```
 
@@ -590,7 +590,7 @@ alias that was created.
 
 - Copy the function ARN from the following command:
 
-  ```bash
+  ```sh
   aws cloudformation describe-stacks --stack-name <stack> --query "Stacks[].Outputs"
   ```
 


### PR DESCRIPTION

## Identify the Bug

Bad labels on fenced code blocks prevented syntax highlighting on much of the code examples. Some uncommon labels like `bash` break highlighting on non-github parsing libs. Incorrect labels like labeling `.ini` config files as `shell` break highlighting everywhere.

## Description of the Change

Changed fenced code block labels. 

Changed 3 long in-lined code blocks to fenced blocks.  Altered accompanying quote blocks for clarity. This was just my own pedantic preference.

Changed `json` to `JSON` in one line because it's and acronym and my cursor was already there. 

## Alternate Designs

Alternates break parsers. It's a bug. Excluding the inline blocks and JSON, of course

## Possible Drawbacks

Some of my changes are not conformant to R Markdown, but are consistent with the rest of the project. Specifically, the lack of extra linefeed characters (newline).

## Verification Process

Parser stopped breaking. Checked the output visually for unintended side-effects

```sh
find ./ -name README.md -execdir pandoc -t html -f gfm -o '{}'.html --standalone '{}' \;
```

## Release Notes

Most examples now have correct syntax highlighting and improved visual clarity. Non-jekyll gfm parsers should now be able to properly identify fenced code blocks by their labels.
