### PR TITLE
Updating links cfn-hup references and os versions

### DIFF
--- a/00-dev-environment/README.md
+++ b/00-dev-environment/README.md
@@ -30,7 +30,8 @@
 
 - DO use the [AWS documentation and user guides](https://aws.amazon.com/documentation/).
 
-- DO use --debug and --event switches on aws cli commands to view the behind-the-curtain actions.
+- DO use --debug and --event switches on aws cli commands to view the
+  behind-the-curtain actions.
 
 ## Lesson 0.1: Setting up your development environment
 
@@ -48,9 +49,10 @@ GitHub code repositories, and, optionally, AWS Cloud9 for your development envir
 
 #### Lab 0.1.1: AWS Access Keys
 
-Save your AWS access key and secret key to a private credentials file on your laptop before enabling 
-MFA.  You won't be able to retrieve your token if the access key and secret key are not added to your 
-credentials file. You will need to [install the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-welcome.html)
+Save your AWS access key and secret key to a private credentials file on your laptop
+before enabling MFA.  You won't be able to retrieve your token if the access
+key and secret key are not added to your credentials file. You will need to
+[install the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-welcome.html)
 and then run some simple commands to confirm access using your keys:
 
 - [list-buckets](https://docs.aws.amazon.com/cli/latest/reference/s3api/list-buckets.html)
@@ -67,7 +69,15 @@ _Never_ commit credentials to a git repo.
   credentials using your MFA device and STS. You can do this in a few
   ways. The first way would be to request the token from STS via the CLI.
 
-##### Option 1: Getting Credentials via STS command (in the AWS console > [user] > Summary page under "Security credentials" tab, use the value for the "Assigned MFA device"). The token-code is your MFA validation code.
+##### Option 1: Getting Credentials via STS command
+
+##### (in the AWS console > [user] >
+
+##### Summary page under "Security credentials" tab
+
+##### use the value for the "Assigned MFA device")
+
+##### The token-code is your MFA validation code
 
 ```shell
 aws sts get-session-token \
@@ -76,7 +86,9 @@ aws sts get-session-token \
 /
 ```
 
-This will return json containing the temporarily credentials.(**WARNING: special characters in the 'SecretAccessKey' may not work for Windoze machines)  
+This will return json containing the temporarily credentials.
+(**WARNING: special characters
+in the 'SecretAccessKey' may not work for Windoze machines)
 
 ```shell
 "Credentials": {

--- a/05-ec2/README.md
+++ b/05-ec2/README.md
@@ -53,7 +53,7 @@
 - DO utilize every link in this document; note how the AWS
   documentation is laid out
 
-- DO use the [AWS CLI for CloudFormation](https://docs.aws.amazon.com/cli/latest/reference/cloudformation/index.html#)
+- DO use the [AWS CLI for CloudFormation](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/cloudformation/index.html)
   (NOT the Console) unless otherwise specified.
 
 - Only specify the minimum configuration required for your resources.
@@ -116,15 +116,15 @@ is created:
 - Create two EC2 instance resources using that same Launch Template
 
   - One instance should use a Windows AMI for Microsoft Windows Server
-    2016 Base
-  - The other instance should be the AMI for Ubuntu 16.04 LTS
+    2022 Base
+  - The other instance should be the AMI for Ubuntu 20.04 LTS
 
 - Launch the instances into the default VPC
 
 Create the stack:
 
 - Write a script that uses the AWS CLI to launch the Stack and immediate
-  employs a [waiter](https://docs.aws.amazon.com/cli/latest/reference/cloudformation/wait/index.html)
+  employs a [waiter](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/cloudformation/wait/index.html)
   so that the script exits only when the CFN service has finished creating the
   stack.
 
@@ -264,9 +264,7 @@ Read and re-read
 of the AWS documentation. In AWS, our goal is generally to replace
 servers that are malfunctioning due to the ease with which virtual
 servers can be automated, but that makes monitoring the health of those
-servers no less important. You can also watch
-[these videos on Linux Academy](https://linuxacademy.com/cp/modules/view/id/163)
-on EC2 monitoring.
+servers no less important. 
 
 A small number of metrics are collected for every EC2 instance, but installing
 the [CloudWatch Agent on instances provides an extended set of metrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/metrics-collected-by-CloudWatch-agent.html).
@@ -293,7 +291,7 @@ you get stuck SSH into the machine and use the logs referenced in the
 Userdata docs to debug.
 
 - Modify your CFN template so that your Launch Template installs and
-  starts the CloudWatch Agent on boot-up of your Ubuntu 16.04 LTS
+  starts the CloudWatch Agent on boot-up of your Ubuntu 20.04 LTS
   Instance.
 
   - Is it necessary to [apply monitoring scripts](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/mon-scripts.html)
@@ -332,7 +330,9 @@ the Metadata attribute and the [cfn-init capability](https://docs.aws.amazon.com
   [Metadata](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/metadata-section-structure.html)
   on your Instance, and migrate the logic that installs and starts
   the CloudWatch Agent into the Init (AWS::CloudFormation::Init)
-  section.
+  section. 
+
+- While using a Ubuntu AMI you will need to create the CFN hup service. An example of this can be found here.[https://aws.amazon.com/premiumsupport/knowledge-center/install-cloudformation-scripts/] AWS::CloudFormation::Init will not run unless the config files and service are created.
 
 - Recreate your stack
 
@@ -345,7 +345,7 @@ Verify that the metrics you expect to see (based on Lab 5.2.2) are still being c
 With YAML's multi-line string syntax, you can embed userdata scripts
 that don't require line "\\n", escapes and other syntactical mess that
 makes the script difficult to read, debug, and reuse. If you haven't
-done this already, try it and repeat Lab 5.2.3.
+done this already, try it and repeat Lab 5.3.2.
 
 > Hint: when you want to put a bunch of commands into UserData in a
 > YAML template, use this format to keep it readable:

--- a/05-ec2/README.md
+++ b/05-ec2/README.md
@@ -264,7 +264,7 @@ Read and re-read
 of the AWS documentation. In AWS, our goal is generally to replace
 servers that are malfunctioning due to the ease with which virtual
 servers can be automated, but that makes monitoring the health of those
-servers no less important. 
+servers no less important.
 
 A small number of metrics are collected for every EC2 instance, but installing
 the [CloudWatch Agent on instances provides an extended set of metrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/metrics-collected-by-CloudWatch-agent.html).
@@ -330,9 +330,12 @@ the Metadata attribute and the [cfn-init capability](https://docs.aws.amazon.com
   [Metadata](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/metadata-section-structure.html)
   on your Instance, and migrate the logic that installs and starts
   the CloudWatch Agent into the Init (AWS::CloudFormation::Init)
-  section. 
+  section.
 
-- While using a Ubuntu AMI you will need to create the CFN hup service. An example of this can be found here.[https://aws.amazon.com/premiumsupport/knowledge-center/install-cloudformation-scripts/] AWS::CloudFormation::Init will not run unless the config files and service are created.
+While using a Ubuntu AMI you will need to create the CFN hup service.
+An example of this can be found here:
+<https://aws.amazon.com/premiumsupport/knowledge-center/install-cloudformation-scripts>
+AWS::CloudFormation::Init will not run unless the config files and service are created.
 
 - Recreate your stack
 

--- a/07-load-balancing/README.md
+++ b/07-load-balancing/README.md
@@ -49,7 +49,7 @@ many instances with an ALB.
 - Working from the [ASG Template](https://github.com/stelligent/stelligent-u/blob/master/07-load-balancing/asg_example.yaml),
   associate a [target group](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html)
   with the autoscaling group, giving it a health check on `/index.html`.
-- Use  Amazon Linux 2 AMI. 
+- Use  Amazon Linux 2 AMI.
 
 - Create an internet-facing ALB
 

--- a/14-Jenkins/README.md
+++ b/14-Jenkins/README.md
@@ -81,10 +81,10 @@ to do this you will need the following:
 You may work off of the provided `base.yaml` template.
 
 Once you have created the CloudFormation template, launch it and navigate
-to the Jenkins instance when complete. Install Jenkins on the EC2 instance, 
-and starting the service. Finally, following the admin install wizard by 
-navigating to the instance IP at the correct port. Verify that Jenkins is 
-set up and ready for use by ensuring the "Welcome to Jenkins!" prompt is 
+to the Jenkins instance when complete. Install Jenkins on the EC2 instance,
+and starting the service. Finally, following the admin install wizard by
+navigating to the instance IP at the correct port. Verify that Jenkins is
+set up and ready for use by ensuring the "Welcome to Jenkins!" prompt is
 present and you can:
 
 - Add a "New Item"


### PR DESCRIPTION
Updating the README for module5 the.
- Updates old links that pointed to the cli 1.X version documentation.
- Added a section talking about cfn-hup service and init.
- Updates the referenced AMI's, 16.04 is no longer an available option on AWS. Windows 2016 base is old.
- Remove LinuxAcademy url as it is no longer reachable. 